### PR TITLE
Fix placeholders and remove covers

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -101,4 +101,13 @@ export const DIVERSIPEDIA_CATEGORIES = [ // Renamed from RESOURCE_CATEGORIES
   { id: 'derechos_humanos', name: 'Derechos Humanos Generales' },
   { id: 'asesoria_legal', name: 'Asesoría Legal' },
   { id: 'salud_bienestar', name: 'Salud y Bienestar' },
+  // Nuevas categorías para Diversipedia
+  { id: 'diversidad_sexual_genero', name: 'Diversidad Sexual y de Género' },
+  { id: 'identidad_etnica_racial', name: 'Identidad Étnica y Racial' },
+  { id: 'salud_mental_emocional', name: 'Salud Mental y Emocional' },
+  { id: 'capacidad_neurodivergencia', name: 'Capacidad y Neurodivergencia' },
+  { id: 'violencias_estructurales_resiliencia', name: 'Violencias Estructurales y Resiliencia' },
+  { id: 'infancias_juventudes_diversas', name: 'Infancias y Juventudes Diversas' },
+  { id: 'memoria_resistencia_archivo', name: 'Memoria, Resistencia y Archivo' },
+  { id: 'recursos_practicos', name: 'Recursos Prácticos' },
 ] as const;

--- a/public/diversipedia-manifest.json
+++ b/public/diversipedia-manifest.json
@@ -3,5 +3,45 @@
     "id": "historia-comunidad-trans",
     "name": "Historia de la Comunidad Trans en México",
     "basePath": "/diversipedia_data/historia-comunidad-trans/"
+  },
+  {
+    "id": "diversidad-sexual-genero",
+    "name": "Diversidad Sexual y de Género",
+    "basePath": "/diversipedia_data/diversidad-sexual-genero/"
+  },
+  {
+    "id": "identidad-etnica-racial",
+    "name": "Identidad Étnica y Racial",
+    "basePath": "/diversipedia_data/identidad-etnica-racial/"
+  },
+  {
+    "id": "salud-mental-emocional",
+    "name": "Salud Mental y Emocional",
+    "basePath": "/diversipedia_data/salud-mental-emocional/"
+  },
+  {
+    "id": "capacidad-neurodivergencia",
+    "name": "Capacidad y Neurodivergencia",
+    "basePath": "/diversipedia_data/capacidad-neurodivergencia/"
+  },
+  {
+    "id": "violencias-estructurales-resiliencia",
+    "name": "Violencias Estructurales y Resiliencia",
+    "basePath": "/diversipedia_data/violencias-estructurales-resiliencia/"
+  },
+  {
+    "id": "infancias-juventudes-diversas",
+    "name": "Infancias y Juventudes Diversas",
+    "basePath": "/diversipedia_data/infancias-juventudes-diversas/"
+  },
+  {
+    "id": "memoria-resistencia-archivo",
+    "name": "Memoria, Resistencia y Archivo",
+    "basePath": "/diversipedia_data/memoria-resistencia-archivo/"
+  },
+  {
+    "id": "recursos-practicos",
+    "name": "Recursos Prácticos",
+    "basePath": "/diversipedia_data/recursos-practicos/"
   }
 ]

--- a/public/diversipedia_data/capacidad-neurodivergencia/config.json
+++ b/public/diversipedia_data/capacidad-neurodivergencia/config.json
@@ -1,0 +1,7 @@
+{
+  "title": "Capacidad y Neurodivergencia",
+  "summary": "Bibliografía escrita por personas con discapacidad, autismo y TDAH, con énfasis en accesibilidad.",
+  "tags": ["Discapacidad", "Autismo", "TDAH", "Accesibilidad", "Inclusión"],
+  "date": "2024-10-25",
+  "category": "capacidad_neurodivergencia"
+}

--- a/public/diversipedia_data/capacidad-neurodivergencia/content.md
+++ b/public/diversipedia_data/capacidad-neurodivergencia/content.md
@@ -1,0 +1,8 @@
+## Literatura desde la Experiencia Discapacitada
+- Obras escritas por personas con discapacidad física o sensorial.
+
+## Perspectivas Autistas y con TDAH
+- Testimonios y herramientas para la vida cotidiana de personas neurodivergentes.
+
+## Accesibilidad Radical
+- Ensayos sobre capacitismo y diseño inclusivo en todos los ámbitos.

--- a/public/diversipedia_data/diversidad-sexual-genero/config.json
+++ b/public/diversipedia_data/diversidad-sexual-genero/config.json
@@ -1,0 +1,7 @@
+{
+  "title": "Diversidad Sexual y de Género",
+  "summary": "Recopilación de literatura, testimonios y guías para personas LGBT+ y trans.",
+  "tags": ["LGBT+", "Trans", "Identidad", "Literatura", "Derechos"],
+  "date": "2024-10-25",
+  "category": "diversidad_sexual_genero"
+}

--- a/public/diversipedia_data/diversidad-sexual-genero/content.md
+++ b/public/diversipedia_data/diversidad-sexual-genero/content.md
@@ -1,0 +1,11 @@
+## Literatura LGBT+ Contemporánea y Clásica
+- Selección de novelas, cuentos y poesía de autoras y autores LGBT+.
+
+## Testimonios y Memorias Trans
+- Autobiografías y relatos de personas trans, no binaries e intersex que narran sus experiencias.
+
+## Guías sobre Identidad y Transición
+- Consejos básicos sobre transición, hormonación y derechos fundamentales.
+
+## Cómics y Novelas Gráficas Queer
+- Recomendaciones de cómics con representación joven y diversa.

--- a/public/diversipedia_data/identidad-etnica-racial/config.json
+++ b/public/diversipedia_data/identidad-etnica-racial/config.json
@@ -1,0 +1,7 @@
+{
+  "title": "Identidad Étnica y Racial",
+  "summary": "Obras y estudios sobre narrativas afrodescendientes, indígenas y migrantes.",
+  "tags": ["Raza", "Etnicidad", "Colonialismo", "Lenguas", "Resistencia"],
+  "date": "2024-10-25",
+  "category": "identidad_etnica_racial"
+}

--- a/public/diversipedia_data/identidad-etnica-racial/content.md
+++ b/public/diversipedia_data/identidad-etnica-racial/content.md
@@ -1,0 +1,8 @@
+## Narrativas Afrodescendientes e Indígenas
+- Autores que relatan experiencias de resistencia y cultura viva.
+
+## Colonialismo y Racismo Estructural
+- Ensayos y análisis sobre la historia colonial y sus efectos actuales.
+
+## Literatura en Lenguas Originarias
+- Obras escritas en lenguas indígenas y sus traducciones al español.

--- a/public/diversipedia_data/infancias-juventudes-diversas/config.json
+++ b/public/diversipedia_data/infancias-juventudes-diversas/config.json
@@ -1,0 +1,7 @@
+{
+  "title": "Infancias y Juventudes Diversas",
+  "summary": "Cuentos, libros juveniles y guías para acompañar a niñxs LGBTI+, racializadxs o con discapacidad.",
+  "tags": ["Infancia", "Juventud", "Educación", "Diversidad", "Inclusión"],
+  "date": "2024-10-25",
+  "category": "infancias_juventudes_diversas"
+}

--- a/public/diversipedia_data/infancias-juventudes-diversas/content.md
+++ b/public/diversipedia_data/infancias-juventudes-diversas/content.md
@@ -1,0 +1,8 @@
+## Cuentos con Familias Diversas
+- Historias para niñxs con distintos modelos familiares y protagonistas trans o neurodivergentes.
+
+## Literatura Juvenil Inclusiva
+- Novelas y relatos que rompen estereotipos de género y belleza.
+
+## Guías para Acompañantes
+- Recursos educativos para docentes y familias de niñxs LGBTI+, racializadxs o con discapacidad.

--- a/public/diversipedia_data/memoria-resistencia-archivo/config.json
+++ b/public/diversipedia_data/memoria-resistencia-archivo/config.json
@@ -1,0 +1,7 @@
+{
+  "title": "Memoria, Resistencia y Archivo",
+  "summary": "Documentos históricos y casos emblemáticos de movimientos sociales y justicia restaurativa.",
+  "tags": ["Historia", "Archivo", "Activismo", "Memoria", "Justicia"],
+  "date": "2024-10-25",
+  "category": "memoria_resistencia_archivo"
+}

--- a/public/diversipedia_data/memoria-resistencia-archivo/content.md
+++ b/public/diversipedia_data/memoria-resistencia-archivo/content.md
@@ -1,0 +1,8 @@
+## Documentos sobre Movimientos Sociales
+- Cronologías y archivos de huelgas, activismos y feminismos del sur global.
+
+## Casos Emblemáticos
+- Testimonios de violencia no olvidada y procesos de reparación simbólica.
+
+## Justicia Restaurativa
+- Material sobre prácticas de verdad y reparación comunitaria.

--- a/public/diversipedia_data/recursos-practicos/config.json
+++ b/public/diversipedia_data/recursos-practicos/config.json
@@ -1,0 +1,7 @@
+{
+  "title": "Recursos Prácticos",
+  "summary": "Manuales y plantillas para defensa legal, primeros auxilios psicológicos y activismo seguro.",
+  "tags": ["Manuales", "Defensa", "Plantillas", "Seguridad", "Activismo"],
+  "date": "2024-10-25",
+  "category": "recursos_practicos"
+}

--- a/public/diversipedia_data/recursos-practicos/content.md
+++ b/public/diversipedia_data/recursos-practicos/content.md
@@ -1,0 +1,8 @@
+## Manuales de Escritura y Defensa Legal
+- Guías paso a paso para redactar testimonios y presentar denuncias.
+
+## Protección Digital y Activismo Seguro
+- Consejos para mantener la privacidad y seguridad en línea al participar en movimientos sociales.
+
+## Plantillas y Cartas Tipo
+- Formatos para quejas, solicitudes y otros trámites ante instituciones.

--- a/public/diversipedia_data/salud-mental-emocional/config.json
+++ b/public/diversipedia_data/salud-mental-emocional/config.json
@@ -1,0 +1,7 @@
+{
+  "title": "Salud Mental y Emocional",
+  "summary": "Textos y guías de autocuidado para enfrentar depresión, ansiedad y trauma.",
+  "tags": ["Salud Mental", "Autocuidado", "Depresión", "Ansiedad", "Guías"],
+  "date": "2024-10-25",
+  "category": "salud_mental_emocional"
+}

--- a/public/diversipedia_data/salud-mental-emocional/content.md
+++ b/public/diversipedia_data/salud-mental-emocional/content.md
@@ -1,0 +1,8 @@
+## Acompañamiento en Depresión y Ansiedad
+- Material de apoyo y recursos de intervención en crisis.
+
+## Autocuidado y Espiritualidades Alternativas
+- Estrategias de bienestar y cuidado colectivo no hegemónico.
+
+## Guías de Primeros Auxilios Emocionales
+- Instrucciones sencillas para sobrevivir un mal día.

--- a/public/diversipedia_data/violencias-estructurales-resiliencia/config.json
+++ b/public/diversipedia_data/violencias-estructurales-resiliencia/config.json
@@ -1,0 +1,7 @@
+{
+  "title": "Violencias Estructurales y Resiliencia",
+  "summary": "Testimonios y guías legales para víctimas de violencia de género e institucional.",
+  "tags": ["Violencia", "Resiliencia", "Derechos", "Refugio", "Justicia"],
+  "date": "2024-10-25",
+  "category": "violencias_estructurales_resiliencia"
+}

--- a/public/diversipedia_data/violencias-estructurales-resiliencia/content.md
+++ b/public/diversipedia_data/violencias-estructurales-resiliencia/content.md
@@ -1,0 +1,8 @@
+## Guías Legales y de Protección
+- Documentos para denunciar violencia de género o discriminación laboral.
+
+## Testimonios de Sobrevivientes
+- Relatos organizados por temas como refugio, cárcel o trabajo sexual.
+
+## Derechos Humanos con Enfoque Interseccional
+- Material educativo para conocer mecanismos de defensa y apoyo.


### PR DESCRIPTION
## Summary
- remove unused `imageUrl` fields from new Diversipedia entries
- replace placeholder bullet points with brief descriptions

## Testing
- `npm install` *(fails: 403 Forbidden)*
