### PR TITLE
Add import map polyfill for mobile browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,8 @@
         }
       }
     </script>
-  <script type="importmap">
+    <script async src="https://ga.jspm.io/npm:es-module-shims@1.8.4/dist/es-module-shims.js"></script>
+    <script type="importmap">
 {
   "imports": {
     "react-dom/": "https://esm.sh/react-dom@19.0.0/",


### PR DESCRIPTION
## Summary
- load `es-module-shims` to polyfill import maps so mobile browsers render the page